### PR TITLE
Make authors array use author names

### DIFF
--- a/Wikiwho.py
+++ b/Wikiwho.py
@@ -540,7 +540,7 @@ def printRevision(revision):
                 #print word
                 #text = text + ' ' + unicode(word.value,'utf-8') + "@@" + str(word.revision) 
                 text.append(word.value)
-                authors.append(word.revision)
+                authors.append(word.author_name)
     print text
     print authors
 


### PR DESCRIPTION
Not sure if it was intended, but currently authors is an array of revision ids, not author names or ids. 
