### PR TITLE
Remove deepcopy usage in revision printing (just like in master branch)

### DIFF
--- a/WikiwhoRelationships.py
+++ b/WikiwhoRelationships.py
@@ -679,11 +679,11 @@ def printRevision(revision):
     text = []
     authors = []
     for hash_paragraph in revision.ordered_paragraphs:
-        p_copy = deepcopy(revision.paragraphs[hash_paragraph])
-        paragraph = p_copy.pop(0)
+        para = revision.paragraphs[hash_paragraph]
+        paragraph = para[-1]
 
         for hash_sentence in paragraph.ordered_sentences:
-            sentence = paragraph.sentences[hash_sentence].pop(0)
+            sentence = paragraph.sentences[hash_sentence][-1]
 
             for word in sentence.words:
                 text.append(word.value)


### PR DESCRIPTION
@maribelacosta introduced a performance improvement in 44025459a35e90c70fa737960dbd034a9e340c01 by removing an unnecessary use of `deepcopy`. However, this would only work with `-o r` but `-o a` would throw an `IndexError`:

``` python
Traceback (most recent call last):
  File "WikiwhoRelationships.py", line 889, in <module>
    printAllRevisions(order, revisions)
  File "WikiwhoRelationships.py", line 723, in printAllRevisions
    printRevision(revisions[revision])
  File "WikiwhoRelationships.py", line 742, in printRevision
    sentence = paragraph.sentences[hash_sentence].pop(0)
IndexError: pop from empty list
```

This error is fixed in this pull request in line 686 of 20ba25a9df54d96ee30660a351d1a2a1d72fb1db.
